### PR TITLE
ci: add a permission to label pr

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,6 +23,7 @@ jobs:
           private-key: ${{ secrets.RELEASE_PRIVATE_KEY }}
           permission-contents: write
           permission-pull-requests: write
+          permission-issues: write
       - uses: googleapis/release-please-action@a02a34c4d625f9be7cb89156071d8567266a2445 # v4.2.0
         id: release
         with:


### PR DESCRIPTION
This pull request includes a minor update to the GitHub Actions workflow configuration. The change grants the `publish.yml` workflow permission to write to issues.

* [`.github/workflows/publish.yml`](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7R26): Added `permission-issues: write` to the workflow's permissions configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow to grant write access to issues during the publishing process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->