### PR TITLE
ci: prepare workflows for pnpm v11

### DIFF
--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -15,5 +15,9 @@ jobs:
         with:
           persist-credentials: false
       - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: lts/*
+          cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm dlx pkg-pr-new publish --pnpm

--- a/package.json
+++ b/package.json
@@ -46,5 +46,12 @@
     "ts-node": "10.9.2",
     "typescript": "5.9.3"
   },
-  "packageManager": "pnpm@10.33.4"
+  "packageManager": "pnpm@10.33.4",
+  "devEngines": {
+    "packageManager": {
+      "name": "pnpm",
+      "version": "10.33.4",
+      "onFail": "error"
+    }
+  }
 }


### PR DESCRIPTION
## Summary

- Add `actions/setup-node` to the `pkg-pr-new` workflow so it runs on a Node.js version that satisfies pnpm v11's `engines` requirement (`>=22.13`, which provides `node:sqlite`). Without this step the workflow uses the runner default (v20.20.2), so any pnpm v11 bump (e.g. #927) immediately fails with `ERR_UNKNOWN_BUILTIN_MODULE: No such built-in module: node:sqlite`.
- Declare `devEngines.packageManager` with `onFail: "error"` so contributors get a hard failure when their local pnpm does not match the pinned version, instead of relying solely on Corepack's softer `packageManager` field.

## Why this is a separate PR

#927 (renovate's `pnpm@11.1.1` bump) cannot pass CI until `pkg-pr-new` installs a compatible Node. Landing this PR first lets renovate rebase #927 onto a green main.

## Test plan

- [ ] CI: `check-typescript` matrix passes
- [ ] CI: `pkg-pr-new` succeeds with `lts/*` Node + pnpm v10
- [ ] After merge, rebase #927 and confirm it goes green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced CI publish workflow to ensure a proper Node.js environment and improved caching for faster, more reliable publish runs.
  * Added explicit development environment requirements by pinning the package manager version and enforcing failure behavior to maintain consistent developer setups.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Omochice/textlint-rule-no-date-without-actual-date/pull/947?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->