### PR TITLE
chore: make tsconfig compatible with TypeScript 7

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,8 +2,9 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "compilerOptions": {
     "module": "ESNext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "esModuleInterop": true,
+    "rootDir": "./src/",
     "outDir": "./lib/",
     "target": "ESNext",
     "sourceMap": true,


### PR DESCRIPTION
## Summary

Replace the `moduleResolution` and `rootDir` settings that TypeScript 7 no longer accepts.

## Details

TypeScript 7 removed `moduleResolution: node10` and stopped inferring `rootDir` from the common source directory, so the `tsc` step of `pnpm test` fails on #1037 before any test runs.

`bundler` is the only remaining resolution mode compatible with `module: ESNext`, and it preserves the extensionless relative imports that the Babel-based build already emits.

## Confirmation

Ran `biome ci`, `textlint-scripts test` and `textlint-scripts build` under both TypeScript 5.9.3 and 7.0.2, and all of them passed.

Compared the emitted declarations against the current baseline of TypeScript 5.9.3 with the previous tsconfig, and they are byte-identical, so nothing changes for consumers of the published package.

## Limitation

This change only unblocks the compiler upgrade; the version bump itself stays in #1037.

`ts-node` is left in devDependencies even though TypeScript 7 breaks it, because nothing in this repository loads it. Removing it is follow-up work.

https://claude.ai/code/session_01CEHniFkdpN5D72W3KfeZGy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated TypeScript build configuration to improve module resolution and source directory handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->