### PR TITLE
chore: drop unused ts-node from devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "textlint": "15.7.1",
     "textlint-scripts": "15.7.1",
     "textlint-tester": "15.7.1",
-    "ts-node": "10.9.2",
     "typescript": "7.0.2"
   },
   "packageManager": "pnpm@11.16.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -247,9 +247,6 @@ importers:
       textlint-tester:
         specifier: 15.7.1
         version: 15.7.1(supports-color@8.1.1)
-      ts-node:
-        specifier: 10.9.2
-        version: 10.9.2(@types/node@24.13.3)(typescript@7.0.2)
       typescript:
         specifier: 7.0.2
         version: 7.0.2
@@ -3356,6 +3353,7 @@ snapshots:
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
+    optional: true
 
   '@hono/node-server@1.19.15(hono@4.12.32)':
     dependencies:
@@ -3393,6 +3391,7 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
+    optional: true
 
   '@keyv/bigmap@1.3.1(keyv@5.6.0)':
     dependencies:
@@ -3553,13 +3552,17 @@ snapshots:
 
   '@textlint/utils@15.7.1': {}
 
-  '@tsconfig/node10@1.0.12': {}
+  '@tsconfig/node10@1.0.12':
+    optional: true
 
-  '@tsconfig/node12@1.0.11': {}
+  '@tsconfig/node12@1.0.11':
+    optional: true
 
-  '@tsconfig/node14@1.0.3': {}
+  '@tsconfig/node14@1.0.3':
+    optional: true
 
-  '@tsconfig/node16@1.0.4': {}
+  '@tsconfig/node16@1.0.4':
+    optional: true
 
   '@types/mdast@3.0.15':
     dependencies:
@@ -3643,8 +3646,10 @@ snapshots:
   acorn-walk@8.3.5:
     dependencies:
       acorn: 8.17.0
+    optional: true
 
-  acorn@8.17.0: {}
+  acorn@8.17.0:
+    optional: true
 
   ajv-formats@3.0.1(ajv@8.20.0):
     optionalDependencies:
@@ -3673,7 +3678,8 @@ snapshots:
       picomatch: 2.3.2
     optional: true
 
-  arg@4.1.3: {}
+  arg@4.1.3:
+    optional: true
 
   argparse@2.0.1: {}
 
@@ -3879,7 +3885,8 @@ snapshots:
       object-assign: 4.1.1
       vary: 1.1.2
 
-  create-require@1.1.1: {}
+  create-require@1.1.1:
+    optional: true
 
   cross-spawn@7.0.6:
     dependencies:
@@ -3907,7 +3914,8 @@ snapshots:
 
   detect-newline@4.0.1: {}
 
-  diff@4.0.4: {}
+  diff@4.0.4:
+    optional: true
 
   diff@7.0.0: {}
 
@@ -4328,7 +4336,8 @@ snapshots:
       pify: 4.0.1
       semver: 5.7.2
 
-  make-error@1.3.6: {}
+  make-error@1.3.6:
+    optional: true
 
   markdown-table@2.0.0:
     dependencies:
@@ -5058,6 +5067,7 @@ snapshots:
       typescript: 7.0.2
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
+    optional: true
 
   type-check@0.4.0:
     dependencies:
@@ -5140,7 +5150,8 @@ snapshots:
       escalade: 3.2.0
       picocolors: 1.1.1
 
-  v8-compile-cache-lib@3.0.1: {}
+  v8-compile-cache-lib@3.0.1:
+    optional: true
 
   validate-npm-package-license@3.0.4:
     dependencies:
@@ -5210,7 +5221,8 @@ snapshots:
       y18n: 5.0.8
       yargs-parser: 21.1.1
 
-  yn@3.1.1: {}
+  yn@3.1.1:
+    optional: true
 
   yocto-queue@0.1.0: {}
 


### PR DESCRIPTION
## Summary

Remove `ts-node` from devDependencies, as nothing in this repository loads it.

## Details

`textlint-scripts test` requires `textlint-scripts/configs/babel-register`, never `register-ts`, so the devDependencies entry was the only reference to `ts-node` anywhere in the repository.

TypeScript 7 also makes the package unusable, because its `exports` map resolves the root entry to a version stub instead of the compiler API, so keeping the entry would declare a dependency that can neither be loaded nor work.

## Confirmation

Installed the regenerated lockfile with `pnpm install --frozen-lockfile` and confirmed `node_modules/ts-node` is absent, then ran `biome ci`, `textlint-scripts test` and `textlint-scripts build`, all of which passed.

## Limitation

pnpm still records `ts-node` in the lockfile as an optional peer of `textlint-scripts`, so it is still fetched during installation. Only the top-level link is gone; removing it entirely would require a change in `textlint-scripts` itself.

https://claude.ai/code/session_01CEHniFkdpN5D72W3KfeZGy