### PR TITLE
chore: download the pinned pnpm instead of failing on a mismatch

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "packageManager": {
       "name": "pnpm",
       "version": "11.16.0",
-      "onFail": "error"
+      "onFail": "download"
     }
   }
 }


### PR DESCRIPTION
## Summary

Change `devEngines.packageManager.onFail` from `error` to `download`.

## Details

With `error`, a contributor whose pnpm differs from the pinned 11.16.0 is stopped before any command runs and has to install the exact version by hand, which the pin was never meant to require.

`download` keeps the guarantee that everyone resolves dependencies under the same pnpm, because pnpm fetches the pinned version and re-executes under it instead of refusing to run.

## Confirmation

Ran `pnpm install --frozen-lockfile`, `pnpm run check` and `pnpm run test` with pnpm 11.9.0 on PATH, and all of them succeeded while reporting `using pnpm v11.16.0`. The same commands abort immediately with `error`.

## Limitation

CI behaviour is unchanged, because `pnpm/action-setup` already installs the version from the `packageManager` field before any script runs, so this only affects local development.

https://claude.ai/code/session_01CEHniFkdpN5D72W3KfeZGy