### PR TITLE
fix: add repository metadata required for provenance publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,10 @@
   "keywords": [
     "textlintrule"
   ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Omochice/textlint-rule-no-date-without-actual-date.git"
+  },
   "license": "MIT",
   "author": "Omochice",
   "type": "module",


### PR DESCRIPTION
## Summary

Add the `repository` field to `package.json` so that publishing with `--provenance` passes registry validation.

## Details

The npm registry rejects a provenance-signed publish when `package.json` "repository.url" does not match the repository recorded in the sigstore bundle, and the field had never been present in this package.

This first became reachable in the v2.0.0 release, because `--provenance` was added after the last successful publish, so the registry returned 422 and v2.0.0 never reached npm.

## Confirmation

Ran `clean-pkg-json --dry` and confirmed the field survives `prepack` into the manifest that is actually published.

Ran `sort-package-json --check` and `biome ci`, both of which passed.

## Limitation

Whether the registry accepts this exact URL form cannot be verified locally, so it is only confirmed once the failed `npm-publish` job is re-run.

Re-running that job requires this change to be on `main` first, because the job checks out `ref: main`.

https://claude.ai/code/session_01CEHniFkdpN5D72W3KfeZGy