### PR TITLE
chore: ignore the pnpm store created inside the repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ npm-debug.log
 
 # Publish src/ instead dist/
 /dist
+
+# pnpm store created when store-dir is resolved inside the repository
+/.pnpm-store


### PR DESCRIPTION
## Summary

Ignore `/.pnpm-store`, which pnpm can create in the repository root.

## Details

When pnpm resolves `store-dir` inside the repository instead of the home directory, the resulting cache shows up as an untracked directory and clutters `git status`.

The entry is anchored to the root so it only matches that specific directory.

## Confirmation

Ran `git check-ignore -v .pnpm-store/` and confirmed it matches the new rule.

## Limitation

No known limitations.

https://claude.ai/code/session_01CEHniFkdpN5D72W3KfeZGy